### PR TITLE
FIX: update the ux url in generate-api page

### DIFF
--- a/codegen-process-guide/domain-modeling/generate-api.md
+++ b/codegen-process-guide/domain-modeling/generate-api.md
@@ -48,4 +48,4 @@ There are actually two "update"-type operations:
 These database access functions can be accessed by screens/web pages generated from wireframes. Linkages between screens and database access functions are specified using UML tagged values.
 
 
-> **[> Next: CodeBot UX - draw wireframes and generate a React web-app](../UX/)**
+> **[> Next: CodeBot UX - draw wireframes and generate a React web-app](../ux)**


### PR DESCRIPTION
* The NEXT link in the `generate-api.md` in the bottom was giving 404 since the permalink for that page is set to `/codegen-process-guide/ux/` rather than `/codegen-process-guide/UX/`. @maffstephens Should I also rename the `UX` folder to lowercase `ux` to keep the folder naming convention consistent ?